### PR TITLE
Update pch.h: fix build error

### DIFF
--- a/pch.h
+++ b/pch.h
@@ -17,7 +17,7 @@
 #endif // WIN32
 
 
-
+#include <cstdint>
 #include <vector>
 #include <array>
 #include <set>


### PR DESCRIPTION
`pch.h:32:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?`